### PR TITLE
Support reading in CSV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ And then execute:
 
 ## Usage
 
+Pass a CSV string with data formatted following the [OCD Division IDs](http://opencivicdata.readthedocs.org/en/latest/proposals/0002.html) standard. Some examples can be found in the [opencivicdata/ocd-division-ids](https://github.com/opencivicdata/ocd-division-ids) repository.
+
 ```ruby
-lookup = OcdLookup::DivisionId.new([{ id: 'ocd-division/country:au/state:nsw', name: 'New South Wales' }])
+csv_data = "id,name\nocd-division/country:au/state:nsw,New South Wales"
+lookup = OcdLookup::DivisionId.parse(csv_data)
 lookup.find(state: 'New South Wales')
 # => "ocd-division/country:au/state:nsw"
 ```

--- a/lib/ocd_lookup.rb
+++ b/lib/ocd_lookup.rb
@@ -1,8 +1,14 @@
 require 'ocd_lookup/version'
+require 'csv'
 
 module OcdLookup
   class DivisionId
     attr_reader :mapping
+
+    def self.parse(csv_data)
+      rows = CSV.parse(csv_data, headers: true, header_converters: :symbol)
+      new(rows.map(&:to_hash))
+    end
 
     def initialize(rows)
       @mapping = Hash[rows.map { |r| [r[:name], r[:id]] }]

--- a/test/ocd_lookup_test.rb
+++ b/test/ocd_lookup_test.rb
@@ -1,18 +1,13 @@
 require 'test_helper'
 require 'pry'
-require 'csv'
 
 class OcdLookupTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::OcdLookup::VERSION
   end
 
-  def country_au_mapping
-    CSV.parse(File.read('test/fixtures/country-au.csv'), headers: true, header_converters: :symbol).map(&:to_hash)
-  end
-
   def subject
-    @lookup ||= OcdLookup::DivisionId.new(country_au_mapping)
+    @lookup ||= OcdLookup::DivisionId.parse(File.read('test/fixtures/country-au.csv'))
   end
 
   def test_looking_up_country


### PR DESCRIPTION
This allows the user to pass a CSV string of OCD Division ID data and
the library will do the right thing with it.

Fixes https://github.com/everypolitician/ocd_lookup/issues/1
